### PR TITLE
Mention unofficial MIME type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Build / Run
 
-You need to have nginx installed. Starting a development server on
+You need to have nginx installed, with application/wasm wasm added to default mime.types (https://github.com/mdn/webassembly-examples/issues/5). Starting a development server on
 port 8080:
 
 ``` shell


### PR DESCRIPTION
My default installation of nginx didn't have the wasm MIME type included. Mentioning it might help noobs like me to get things up more smoothly.